### PR TITLE
Fix bug #12 - Make logic clearer; remove unnecessary method; Separate out `DescriptorUtils`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -455,7 +455,8 @@ class DeepOverrideHost {
 
   /****************************************************************************************/
 
-  private splitter: RegExp;
+  private reSplit = /^([^\\\.]|\\.)*?\./;
+  private reUnescape = /\\(.)/g;
 
   throwPathError(): never {
     throw DEBUG ? new Error("Malformed path string") : 1;
@@ -464,7 +465,8 @@ class DeepOverrideHost {
   buildAbstractStateTree(path: string, root?: IObjectState): IPropertyState {
     path += '.';
     root = root || new DeepOverrideHost.ObjectState();
-    let splitter = this.splitter || (this.splitter = /^([^\\\.]|\\.)*?\./);
+    let reSplit = this.reSplit;
+    let reUnescape = this.reUnescape;
 
     let data: IObjectState = root;
     let match: RegExpMatchArray | null;
@@ -473,12 +475,12 @@ class DeepOverrideHost {
     let nextData: IObjectState;
     let propData: IPropertyState | undefined;
     while (path) {
-      match = splitter.exec(path);
+      match = reSplit.exec(path);
       if (match === null) {
         return this.throwPathError();
       }
       matchLength = match[0].length;
-      prop = path.slice(0, matchLength - 1);
+      prop = path.slice(0, matchLength - 1).replace(reUnescape, '$1');
       path = path.slice(matchLength);
       propData = data.ownProps[prop];
       if (!propData) {
@@ -585,7 +587,6 @@ abstract class DescriptorUtils {
       enumerable: true
     };
   }
-
 
   static defineProperty = defineProperty;
   static getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;

--- a/index.ts
+++ b/index.ts
@@ -520,7 +520,7 @@ abstract class DescriptorUtils {
     return 'beforeGet' in desc || 'beforeSet' in desc;
   }
 
-  private static readonly DESC_KEYS = ["cofigurable", "enumerable", "value", "get", "set", "writable"];
+  private static readonly DESC_KEYS = ["configurable", "enumerable", "value", "get", "set", "writable"];
   private static readonly GENERIC_DESC_KEYS = DescriptorUtils.DESC_KEYS.slice(0, 2);
 
   // Helper function to be used for functions that clones property descriptors

--- a/test/index.js
+++ b/test/index.js
@@ -415,6 +415,27 @@ suite('AG_defineProperty', function() {
             base.a.b.c.d = 2;
             assert.equal(setCount, 1);
         })
+
+        test('Generic property descriptor keys should be applied', function() {
+            base.a = 1;
+            assert.ok(base.propertyIsEnumerable('a'));
+
+            let getCount = 0;
+            AG_defineProperty('a', {
+                beforeGet: function() {
+                    getCount++;
+                },
+                enumerable: false,
+                configurable: false
+            }, base);
+
+            assert.notOk(base.propertyIsEnumerable('a'));
+            assert.equal(base.a, 1);
+            assert.equal(getCount, 1);
+
+            let desc = Object.getOwnPropertyDescriptor(base, 'a');
+            assert.equal(desc.configurable, false);
+        });
     });
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -151,7 +151,7 @@ suite('AG_defineProperty', function() {
                 value: { b: 0 },
                 writable: true
             });
-            
+
             let test0 = base.test0 = tmp;
 
             var getCount = setCount = 0;
@@ -166,6 +166,26 @@ suite('AG_defineProperty', function() {
             test0.a.b = 0;
             //assert.equal(setCount, 1);
             assert.equal(test0.a.b, 1);
+        });
+
+        test('Overriding nested properties of non-configurable property', function() {
+            /**
+             * This showcases a bug #12
+             * {@link https://github.com/AdguardTeam/deep-override/issues/12}
+             */
+            Object.defineProperty(base, 'a', {
+                value: {},
+                writable: true,
+                enumerable: true,
+                configurable: false
+            });
+
+            AG_defineProperty('a.b', { value: 1 }, base);
+            AG_defineProperty('a.c.d', { value: 2 }, base);
+
+            base.a.c = {};
+
+            assert.equal(base.a.c.d, 2);
         });
 
         test('It should concatenate recursion', function() {
@@ -250,7 +270,7 @@ suite('AG_defineProperty', function() {
             test.a.b = 3;
             test.c = test.a;
             test.c.d = 4;
-            
+
             assert.equal(test.a.b, 1);
             assert.equal(test.c.d, 2);
             assert.equal(test.a.d, 2);
@@ -264,7 +284,7 @@ suite('AG_defineProperty', function() {
 
         test('Re-assign test', function() {
             AG_defineProperty(`test.a`, { value: 1 }, base);
-            
+
             let test = base.test = {};
             assert.equal(test.a, 1);
 
@@ -311,7 +331,7 @@ suite('AG_defineProperty', function() {
             ptypeHasGetter.setCount = 0;
 
             base.test = ptypeHasGetter;
-            
+
             let getCount = 0;
             let setCount = 0;
             AG_defineProperty('test.a.b', {
@@ -345,7 +365,7 @@ suite('AG_defineProperty', function() {
                             return 0;
                         },
                         set d(i) {
-                            
+
                         }
                     }))))
                 }

--- a/test/index.js
+++ b/test/index.js
@@ -35,11 +35,11 @@ suite('AG_defineProperty', function() {
             test1.a = { d : 3 };
             test1 = base.test1 = { a : 4, c : 5 };
             test1.a = {};
-            test1.a.b = 4;
-            test1.a = { b : { e : 6 }, c : 7 };
+            test1.a.b = 4;                      // setCount is 1
+            test1.a = { b : { e : 6 }, c : 7 }; // setCount is 2
 
             assert.equal(test1.c, 5);
-            // assert.equal(setCount, 1);
+            assert.equal(setCount, 2);
             assert.equal(getCount, 0);
             assert.equal(test1.a.b, 1);
             assert.equal(getCount, 1);
@@ -74,11 +74,11 @@ suite('AG_defineProperty', function() {
                 value: { b: 0 },
                 writable: true
             });
-            let test = base.test = tmp;
+            let test = base.test = tmp;  // setCount is 1
             assert.equal(test.a.b, 1);
             assert.equal(getCount, 1);
-            test.a.b = 0;
-            //assert.equal(setCount, 1);
+            test.a.b = 0;                // setCount is 2
+            assert.equal(setCount, 2);
             assert.equal(test.a.b, 1);
         });
 
@@ -100,15 +100,15 @@ suite('AG_defineProperty', function() {
 
             let test6 = base.test6 = {};
             test6.a = {};
-            test6.a.b = 2;
+            test6.a.b = 2;                  // setCount1 is 1
 
-            //assert.equal(setCount1, 1);
+            assert.equal(setCount1, 1);
             assert.equal(test6.a.b, 1);
             assert.equal(getCount1, 1);
 
-            test6.a.c = 2;
+            test6.a.c = 2;                  // setCount2 is 1
 
-            //assert.equal(setCount2, 1);
+            assert.equal(setCount2, 1);
             assert.equal(test6.a.c, 1);
             assert.equal(getCount2, 1);
         });

--- a/test/index.js
+++ b/test/index.js
@@ -437,6 +437,16 @@ suite('AG_defineProperty', function() {
             assert.equal(desc.configurable, false);
         });
     });
+
+    suite('Parsing path', function() {
+        test('should parse escaped properties correctly', function() {
+            AG_defineProperty('ಠ_ಠ\b\f.\n\\.\\r\r\t\x2e\v', { value: true }, base);
+
+            base["ಠ_ಠ\b\f"] = {};
+            base["ಠ_ಠ\b\f"]["\n.r\r\t"] = {};
+            expect(base["ಠ_ಠ\b\f"]["\n.r\r\t"]["\v"]).to.equal(true);
+        });
+    })
 });
 
 


### PR DESCRIPTION
This fixes https://github.com/AdguardTeam/deep-override/issues/12: an issue reported by @AdamWr affecting a filter for `wp.pl` on browser extensions.

While fixing it I improved some other points:
 - Generic property descriptors in access side-effect descriptors are not being applied
 - most of static methods are now moved to `DescriptorUtils`
