### PR TITLE
Fix mocha tests & Update tsickle and typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "mocha": "^4.0.1",
     "replace-in-file": "^3.0.0-beta.2",
     "rewire": "^2.5.2",
-    "tsickle": "^0.25.5",
-    "typescript": "2.5.3"
+    "tsickle": "^0.28.0",
+    "typescript": "2.8.3"
   }
 }

--- a/tasks/tsconfig.json
+++ b/tasks/tsconfig.json
@@ -5,7 +5,7 @@
         "outDir": "../build/tscc",
         "module": "commonjs"
     },
-    "include": [
-        "../index.ts"
+    "files": [
+        "../../index.ts"
     ]
 }

--- a/test/index.js
+++ b/test/index.js
@@ -16,7 +16,7 @@ try { DeepOverrideHost = Module.__get__('DeepOverrideHost'); } catch (e) { }
 suite('AG_defineProperty', function() {
     let base;
 
-    beforeEach(function() {
+    setup(function() {
         base = {};
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,6 +39,10 @@ browser-stdout@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.0.tgz#f351d32969d32fa5d7a5567154263d928ae3bd1f"
 
+buffer-from@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.0.0.tgz#4cb8832d23612589b0406e9e2956c17f06fdf531"
+
 builtin-modules@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
@@ -558,15 +562,20 @@ signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
-source-map-support@^0.4.2:
-  version "0.4.18"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
+source-map-support@^0.5.0:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.6.tgz#4435cee46b1aab62b8e8610ce60f788091c51c13"
   dependencies:
-    source-map "^0.5.6"
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
 
-source-map@^0.5.1, source-map@^0.5.6:
+source-map@^0.5.1:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+
+source-map@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
 spdx-correct@~1.0.0:
   version "1.0.2"
@@ -640,22 +649,22 @@ through2@^2.0.1:
     readable-stream "^2.1.5"
     xtend "~4.0.1"
 
-tsickle@^0.25.5:
-  version "0.25.5"
-  resolved "https://registry.yarnpkg.com/tsickle/-/tsickle-0.25.5.tgz#2891d29f97c4aab1306e06378d8496d1765a4bfe"
+tsickle@^0.28.0:
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/tsickle/-/tsickle-0.28.0.tgz#6cd6fa004766c6ad9261b599c83866ee97cc7875"
   dependencies:
     minimist "^1.2.0"
     mkdirp "^0.5.1"
-    source-map "^0.5.6"
-    source-map-support "^0.4.2"
+    source-map "^0.6.0"
+    source-map-support "^0.5.0"
 
 type-detect@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.3.tgz#0e3f2670b44099b0b46c284d136a7ef49c74c2ea"
 
-typescript@2.5.3:
-  version "2.5.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.3.tgz#df3dcdc38f3beb800d4bc322646b04a3f6ca7f0d"
+typescript@2.8.3:
+  version "2.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.3.tgz#5d817f9b6f31bb871835f4edf0089f21abe6c170"
 
 universalify@^0.1.0:
   version "0.1.1"


### PR DESCRIPTION
While working on stealth-script I noticed that, although almost not documented, one should use `setup` and `teardown` instead of `before` and `after` for tdd interface.
`before` and `after` still kinds of works, which is weird, but has subtle problems, such as when there are multiple `before` calls, only one among them are registered. In the unit test of this repository, there was only one `before` call, so such a problem wasn't surfaced.
Also this pull request contains updating tsickle and typescript to latest versions. This pull request does not change the build output.